### PR TITLE
Make example `go get`-able

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-mongo-quickstart
+module github.com/tigrisdata-community/go-mongo-quickstart
 
 go 1.19
 


### PR DESCRIPTION
It also allows dependency analysis tools to work:

* https://pkg.go.dev/github.com/FerretDB/FerretDB/ferretdb?tab=importedby
* https://pkg.go.dev/github.com/tigrisdata-community/go-mongo-quickstart
* etc